### PR TITLE
Corrigindo a formatação de moeda

### DIFF
--- a/Simple.Brazilian/Formatters/Numbers.cs
+++ b/Simple.Brazilian/Formatters/Numbers.cs
@@ -8,7 +8,11 @@ namespace Simple.Brazilian.Formatters
         public static CultureInfo DefaultCulture { get; }
         static Numbers()
         {
+#if NETSTANDARD1_0
+            DefaultCulture = new CultureInfo("pt-BR");
+#else
             DefaultCulture = new CultureInfo("pt-BR", false);
+#endif
         }
 
         public static int ToInt(string text, int? OnError = 0)

--- a/Simple.Brazilian/Formatters/Numbers.cs
+++ b/Simple.Brazilian/Formatters/Numbers.cs
@@ -8,8 +8,7 @@ namespace Simple.Brazilian.Formatters
         public static CultureInfo DefaultCulture { get; }
         static Numbers()
         {
-            DefaultCulture = new CultureInfo("pt-BR");
-            DefaultCulture.NumberFormat.CurrencySymbol = "R$ ";
+            DefaultCulture = new CultureInfo("pt-BR", false);
         }
 
         public static int ToInt(string text, int? OnError = 0)

--- a/Simple.Brazilian/Formatters/Numbers.cs
+++ b/Simple.Brazilian/Formatters/Numbers.cs
@@ -9,6 +9,7 @@ namespace Simple.Brazilian.Formatters
         static Numbers()
         {
             DefaultCulture = new CultureInfo("pt-BR");
+            DefaultCulture.NumberFormat.CurrencySymbol = "R$ ";
         }
 
         public static int ToInt(string text, int? OnError = 0)


### PR DESCRIPTION
Isto elimina os 22 erros nos unit tests relacionados a moedas, corretamente formatando o Real como esperado nos testes.